### PR TITLE
Setup buildx for multi-platform tag build

### DIFF
--- a/.github/workflows/build_and_publish_tag.yml
+++ b/.github/workflows/build_and_publish_tag.yml
@@ -16,6 +16,14 @@ jobs:
       - name: 🚂 Get latest code
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: ✨ Log into registry
         run: echo "${{ secrets.DOCKER_LOGIN_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_LOGIN_USERNAME }} --password-stdin
 


### PR DESCRIPTION
This probably should be enough?
Seems like you no longer can build multi-platform images by default

You can see problem here https://github.com/PlugFox/docker_flutter/actions/runs/4673898810/jobs/8277576194