### PR TITLE
Restore original makefiles and not use buildx

### DIFF
--- a/.github/workflows/build_and_publish_tag.yml
+++ b/.github/workflows/build_and_publish_tag.yml
@@ -16,14 +16,6 @@ jobs:
       - name: 🚂 Get latest code
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: ✨ Log into registry
         run: echo "${{ secrets.DOCKER_LOGIN_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_LOGIN_USERNAME }} --password-stdin
 

--- a/tools/makefile/build.mk
+++ b/tools/makefile/build.mk
@@ -5,15 +5,15 @@
 # make build VERSION="<VERSION OR CHANNEL>" e.g. make build VERSION="stable"
 build:
 	@echo "BUILD FLUTTER $(VERSION)"
-	@docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --compress \
+	@docker build --compress \
 		 --file ./dockerfiles/flutter.dockerfile \
 		 --build-arg VERSION=$(VERSION) \
 		 --tag plugfox/flutter:$(VERSION) .
-	@docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --compress \
+	@docker build --compress \
 		 --file ./dockerfiles/flutter_web.dockerfile \
 		 --build-arg VERSION=$(VERSION) \
 		 --tag "plugfox/flutter:$(VERSION)-web" .
-	@docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --compress \
+	@docker build --compress \
 		 --file ./dockerfiles/flutter_android.dockerfile \
 		 --build-arg VERSION=$(VERSION) \
 		 --tag "plugfox/flutter:$(VERSION)-android" .


### PR DESCRIPTION
I didn't notice when from buildx came originally but it seems @zs-dima introduced it for regular x86 build, even though it didn't work properly in CI.
So I think it is good to restore it back as it was since @zs-dima introduced new workflow for arm
I'm not sure though why docker buildx doesn't work properly, but I'm unfortunately on windows so I do not have ability to test it locally

